### PR TITLE
python 2.7 fixes for numpy 1.15

### DIFF
--- a/skimage/morphology/greyreconstruct.py
+++ b/skimage/morphology/greyreconstruct.py
@@ -158,8 +158,8 @@ def reconstruction(seed, mask, method='dilation', selem=None, offset=None):
         raise ValueError("Reconstruction method can be one of 'erosion' "
                          "or 'dilation'. Got '%s'." % method)
     images = np.ones(dims) * pad_value
-    images[(0, *inside_slices)] = seed
-    images[(1, *inside_slices)] = mask
+    images[(0, ) + inside_slices] = seed
+    images[(1, ) + inside_slices] = mask
 
     # Create a list of strides across the array to get the neighbors within
     # a flattened array

--- a/skimage/novice/_novice.py
+++ b/skimage/novice/_novice.py
@@ -215,7 +215,7 @@ class Picture(object):
     Load an image from a URL (the URL must start with ``http(s)://`` or
     ``ftp(s)://``):
 
-    >>> picture = novice.open('http://scikit-image.org/_static/img/logo.png')
+    >>> picture = novice.open('https://scikit-image.org/_static/img/logo.png')  # doctest: +SKIP
 
     Create a blank 100 pixel wide, 200 pixel tall white image:
 

--- a/skimage/restoration/_cycle_spin.py
+++ b/skimage/restoration/_cycle_spin.py
@@ -165,5 +165,5 @@ def cycle_spin(x, func, max_shifts, shift_steps=1, num_workers=None,
         # multithreaded via dask
         futures = [dask.delayed(_run_one_shift)(s) for s in all_shifts]
         mean = sum(futures) / len(futures)
-        mean = mean.compute(get=dask.threaded.get, num_workers=num_workers)
+        mean = mean.compute(num_workers=num_workers)
     return mean


### PR DESCRIPTION
Fixes the two main warnings.

Also combines https://github.com/scikit-image/scikit-image/pull/3205


## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]


## References
[If this is a bug-fix or enhancement, it closes issue # ]
[If this is a new feature, it implements the following paper: ]

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
